### PR TITLE
Removed System.TriggerOperation triggerEvent parameter

### DIFF
--- a/src/classes/AccountTriggerHandler.cls
+++ b/src/classes/AccountTriggerHandler.cls
@@ -10,20 +10,20 @@
  * @date Sat Dec 29, 2018
  */
 public class AccountTriggerHandler implements ITriggerHandler {
-  /* 
-    Allows unit tests (or other code) to disable this trigger for the transaction
-    To stop this trigger from firing while in a unit test, I could just add the following code to the test:
-    AccountTriggerHandler.TriggerDisabled = true;
-  */
+  /**
+   * Allows unit tests (or other code) to disable this trigger for the transaction
+   * To stop this trigger from firing while in a unit test, I could just add the following code to the test:
+   * AccountTriggerHandler.TriggerDisabled = true;
+   */
   public static Boolean TriggerDisabled = false;
-  /*
-    Checks to see if the trigger has been disabled. For example, you could check a custom setting here.
-    In this example, a static property is used to disable the trigger.
-    In a unit test, you could use AccountTriggerHandler.TriggerDisabled = true to completely disable the trigger.
-  */
+  /**
+   * Checks to see if the trigger has been disabled. For example, you could check a custom setting here.
+   * In this example, a static property is used to disable the trigger.
+   * In a unit test, you could use AccountTriggerHandler.TriggerDisabled = true to completely disable the trigger.
+   */
   public Boolean IsDisabled() {
     /*
-      Use the option below if you set up Custom Settings to controll Triggers
+      Use the option below if you set up Custom Settings to control Triggers
     */
     // if(TriggerSettings__c.AccountTriggerDisabled__c = true) {
     //   return true;

--- a/src/classes/TriggerDispatcher.cls
+++ b/src/classes/TriggerDispatcher.cls
@@ -9,11 +9,11 @@
  * @date Sat Dec 29, 2018
  */
 public class TriggerDispatcher {
-  /*
-    Call this method from your trigger, passing in an instance of a trigger handler which implements ITriggerHandler.
-    This method will fire the appropriate methods on the handler depending on the trigger context.
-  */
-  public static void Run(ITriggerHandler handler, System.TriggerOperation triggerEvent)
+  /**
+   * Call this method from your trigger, passing in an instance of a trigger handler which implements ITriggerHandler.
+   * This method will fire the appropriate methods on the handler depending on the trigger context.
+   */
+  public static void Run(ITriggerHandler handler)
   {
     // Check to see if the trigger has been disabled. If it has, return
     if(handler.IsDisabled())
@@ -21,7 +21,7 @@ public class TriggerDispatcher {
 
     // Detect the current trigger context and fire the relevant methods on the trigger handler:
   
-    switch on triggerEvent {
+    switch on Trigger.operationType {
       when BEFORE_INSERT {
         handler.BeforeInsert(trigger.new);
       } when BEFORE_UPDATE {

--- a/src/triggers/AccountTrigger.trigger
+++ b/src/triggers/AccountTrigger.trigger
@@ -11,6 +11,6 @@
  * @date Sat Dec 29, 2018
  */
 trigger AccountTrigger on Account (before insert, before update, before delete, after insert, after update, after delete, after undelete) {
-  // Call the trigger dispatcher and pass it an instance of the AccountTriggerHandler and Trigger.opperationType
-  TriggerDispatcher.Run(new AccountTriggerHandler(), Trigger.operationType);
+  // Call the trigger dispatcher and pass it an instance of the AccountTriggerHandler
+  TriggerDispatcher.Run(new AccountTriggerHandler());
 }


### PR DESCRIPTION
I don't think we need the  System.TriggerOperation triggerEvent parameter in the TriggerDispatcher class.

I've been running the code similar to this pull request for years.

Feedback requested and welcome!