### PR TITLE
AfterUndelete oldMap is empty

### DIFF
--- a/src/classes/TriggerDispatcher.cls
+++ b/src/classes/TriggerDispatcher.cls
@@ -35,7 +35,7 @@ public class TriggerDispatcher {
       } when AFTER_DELETE {
         handler.AfterDelete(trigger.oldMap);
       } when AFTER_UNDELETE {
-        handler.AfterUndelete(trigger.oldMap);
+        handler.AfterUndelete(trigger.newMap);
       }
     }  
   }


### PR DESCRIPTION
The trigger.oldMap or old is empty on undelete, the newMap contains the undeleted values.