### PR TITLE
Update TriggerDispatcher.cls

### DIFF
--- a/src/classes/TriggerDispatcher.cls
+++ b/src/classes/TriggerDispatcher.cls
@@ -35,7 +35,7 @@ public class TriggerDispatcher {
       } when AFTER_DELETE {
         handler.AfterDelete(trigger.oldMap);
       } when AFTER_UNDELETE {
-        handler.AfterUndelete(trigger.oldMap);
+        handler.AfterUndelete(trigger.newMap);
       }
     }  
   }


### PR DESCRIPTION
FYI: https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_triggers_context_variables.htm
Undelete trigger does not have the oldmap context variable.